### PR TITLE
[TEST] SeccompProfile CRD: add new fields for seccomp notify

### DIFF
--- a/api/seccompprofile/v1beta1/seccompprofile_types.go
+++ b/api/seccompprofile/v1beta1/seccompprofile_types.go
@@ -44,10 +44,14 @@ type SeccompProfileSpec struct {
 
 	// the default action for seccomp
 	//nolint:lll
-	// +kubebuilder:validation:Enum=SCMP_ACT_KILL;SCMP_ACT_KILL_PROCESS;SCMP_ACT_KILL_THREAD;SCMP_ACT_TRAP;SCMP_ACT_ERRNO;SCMP_ACT_TRACE;SCMP_ACT_ALLOW;SCMP_ACT_LOG
+	// +kubebuilder:validation:Enum=SCMP_ACT_KILL;SCMP_ACT_KILL_PROCESS;SCMP_ACT_KILL_THREAD;SCMP_ACT_TRAP;SCMP_ACT_ERRNO;SCMP_ACT_TRACE;SCMP_ACT_ALLOW;SCMP_ACT_LOG;SCMP_ACT_NOTIFY
 	DefaultAction seccomp.Action `json:"defaultAction"`
 	// the architecture used for system calls
 	Architectures []Arch `json:"architectures,omitempty"`
+	// path of UNIX domain socket to contact a seccomp agent for SCMP_ACT_NOTIFY
+	ListenerPath string `json:"listenerPath,omitempty"`
+	// opaque data to pass to the seccomp agent
+	ListenerMetadata string `json:"listenerMetadata,omitempty"`
 	// match a syscall in seccomp. While this property is OPTIONAL, some values
 	// of defaultAction are not useful without syscalls entries. For example,
 	// if defaultAction is SCMP_ACT_KILL and syscalls is empty or unset, the
@@ -73,7 +77,7 @@ type Syscall struct {
 	Names []string `json:"names"`
 	// the action for seccomp rules
 	//nolint:lll
-	// +kubebuilder:validation:Enum=SCMP_ACT_KILL;SCMP_ACT_KILL_PROCESS;SCMP_ACT_KILL_THREAD;SCMP_ACT_TRAP;SCMP_ACT_ERRNO;SCMP_ACT_TRACE;SCMP_ACT_ALLOW;SCMP_ACT_LOG
+	// +kubebuilder:validation:Enum=SCMP_ACT_KILL;SCMP_ACT_KILL_PROCESS;SCMP_ACT_KILL_THREAD;SCMP_ACT_TRAP;SCMP_ACT_ERRNO;SCMP_ACT_TRACE;SCMP_ACT_ALLOW;SCMP_ACT_LOG;SCMP_ACT_NOTIFY
 	Action seccomp.Action `json:"action"`
 	// the errno return code to use. Some actions like SCMP_ACT_ERRNO and
 	// SCMP_ACT_TRACE allow to specify the errno code to return

--- a/deploy/base/crds/seccompprofile.yaml
+++ b/deploy/base/crds/seccompprofile.yaml
@@ -89,6 +89,7 @@ spec:
                 - SCMP_ACT_TRACE
                 - SCMP_ACT_ALLOW
                 - SCMP_ACT_LOG
+                - SCMP_ACT_NOTIFY
                 type: string
               flags:
                 description: list of flags to use with seccomp(2)
@@ -99,6 +100,13 @@ spec:
                   - SECCOMP_FILTER_FLAG_SPEC_ALLOW
                   type: string
                 type: array
+              listenerMetadata:
+                description: opaque data to pass to the seccomp agent
+                type: string
+              listenerPath:
+                description: path of UNIX domain socket to contact a seccomp agent
+                  for SCMP_ACT_NOTIFY
+                type: string
               syscalls:
                 description: match a syscall in seccomp. While this property is OPTIONAL,
                   some values of defaultAction are not useful without syscalls entries.
@@ -119,6 +127,7 @@ spec:
                       - SCMP_ACT_TRACE
                       - SCMP_ACT_ALLOW
                       - SCMP_ACT_LOG
+                      - SCMP_ACT_NOTIFY
                       type: string
                     args:
                       description: the specific syscall in seccomp

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -300,6 +300,7 @@ spec:
                 - SCMP_ACT_TRACE
                 - SCMP_ACT_ALLOW
                 - SCMP_ACT_LOG
+                - SCMP_ACT_NOTIFY
                 type: string
               flags:
                 description: list of flags to use with seccomp(2)
@@ -310,6 +311,13 @@ spec:
                   - SECCOMP_FILTER_FLAG_SPEC_ALLOW
                   type: string
                 type: array
+              listenerMetadata:
+                description: opaque data to pass to the seccomp agent
+                type: string
+              listenerPath:
+                description: path of UNIX domain socket to contact a seccomp agent
+                  for SCMP_ACT_NOTIFY
+                type: string
               syscalls:
                 description: match a syscall in seccomp. While this property is OPTIONAL,
                   some values of defaultAction are not useful without syscalls entries.
@@ -330,6 +338,7 @@ spec:
                       - SCMP_ACT_TRACE
                       - SCMP_ACT_ALLOW
                       - SCMP_ACT_LOG
+                      - SCMP_ACT_NOTIFY
                       type: string
                     args:
                       description: the specific syscall in seccomp

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -300,6 +300,7 @@ spec:
                 - SCMP_ACT_TRACE
                 - SCMP_ACT_ALLOW
                 - SCMP_ACT_LOG
+                - SCMP_ACT_NOTIFY
                 type: string
               flags:
                 description: list of flags to use with seccomp(2)
@@ -310,6 +311,13 @@ spec:
                   - SECCOMP_FILTER_FLAG_SPEC_ALLOW
                   type: string
                 type: array
+              listenerMetadata:
+                description: opaque data to pass to the seccomp agent
+                type: string
+              listenerPath:
+                description: path of UNIX domain socket to contact a seccomp agent
+                  for SCMP_ACT_NOTIFY
+                type: string
               syscalls:
                 description: match a syscall in seccomp. While this property is OPTIONAL,
                   some values of defaultAction are not useful without syscalls entries.
@@ -330,6 +338,7 @@ spec:
                       - SCMP_ACT_TRACE
                       - SCMP_ACT_ALLOW
                       - SCMP_ACT_LOG
+                      - SCMP_ACT_NOTIFY
                       type: string
                     args:
                       description: the specific syscall in seccomp

--- a/deploy/openshift.yaml
+++ b/deploy/openshift.yaml
@@ -300,6 +300,7 @@ spec:
                 - SCMP_ACT_TRACE
                 - SCMP_ACT_ALLOW
                 - SCMP_ACT_LOG
+                - SCMP_ACT_NOTIFY
                 type: string
               flags:
                 description: list of flags to use with seccomp(2)
@@ -310,6 +311,13 @@ spec:
                   - SECCOMP_FILTER_FLAG_SPEC_ALLOW
                   type: string
                 type: array
+              listenerMetadata:
+                description: opaque data to pass to the seccomp agent
+                type: string
+              listenerPath:
+                description: path of UNIX domain socket to contact a seccomp agent
+                  for SCMP_ACT_NOTIFY
+                type: string
               syscalls:
                 description: match a syscall in seccomp. While this property is OPTIONAL,
                   some values of defaultAction are not useful without syscalls entries.
@@ -330,6 +338,7 @@ spec:
                       - SCMP_ACT_TRACE
                       - SCMP_ACT_ALLOW
                       - SCMP_ACT_LOG
+                      - SCMP_ACT_NOTIFY
                       type: string
                     args:
                       description: the specific syscall in seccomp

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -300,6 +300,7 @@ spec:
                 - SCMP_ACT_TRACE
                 - SCMP_ACT_ALLOW
                 - SCMP_ACT_LOG
+                - SCMP_ACT_NOTIFY
                 type: string
               flags:
                 description: list of flags to use with seccomp(2)
@@ -310,6 +311,13 @@ spec:
                   - SECCOMP_FILTER_FLAG_SPEC_ALLOW
                   type: string
                 type: array
+              listenerMetadata:
+                description: opaque data to pass to the seccomp agent
+                type: string
+              listenerPath:
+                description: path of UNIX domain socket to contact a seccomp agent
+                  for SCMP_ACT_NOTIFY
+                type: string
               syscalls:
                 description: match a syscall in seccomp. While this property is OPTIONAL,
                   some values of defaultAction are not useful without syscalls entries.
@@ -330,6 +338,7 @@ spec:
                       - SCMP_ACT_TRACE
                       - SCMP_ACT_ALLOW
                       - SCMP_ACT_LOG
+                      - SCMP_ACT_NOTIFY
                       type: string
                     args:
                       description: the specific syscall in seccomp

--- a/internal/pkg/daemon/seccompprofile/seccompprofile.go
+++ b/internal/pkg/daemon/seccompprofile/seccompprofile.go
@@ -183,10 +183,12 @@ func (r *Reconciler) Reconcile(_ context.Context, req reconcile.Request) (reconc
 
 // OutputProfile represents the on-disk form of the SeccompProfile.
 type OutputProfile struct {
-	DefaultAction seccomp.Action               `json:"defaultAction"`
-	Architectures []seccompprofileapi.Arch     `json:"architectures,omitempty"`
-	Syscalls      []*seccompprofileapi.Syscall `json:"syscalls,omitempty"`
-	Flags         []*seccompprofileapi.Flag    `json:"flags,omitempty"`
+	DefaultAction    seccomp.Action               `json:"defaultAction"`
+	Architectures    []seccompprofileapi.Arch     `json:"architectures,omitempty"`
+	ListenerPath     string                       `json:"listenerPath,omitempty"`
+	ListenerMetadata string                       `json:"listenerMetadata,omitempty"`
+	Syscalls         []*seccompprofileapi.Syscall `json:"syscalls,omitempty"`
+	Flags            []*seccompprofileapi.Flag    `json:"flags,omitempty"`
 }
 
 func unionSyscalls(baseSyscalls, appliedSyscalls []*seccompprofileapi.Syscall) []*seccompprofileapi.Syscall {
@@ -220,9 +222,11 @@ func (r *Reconciler) mergeBaseProfile(
 	ctx context.Context, sp *seccompprofileapi.SeccompProfile, l logr.Logger,
 ) (OutputProfile, error) {
 	op := OutputProfile{
-		DefaultAction: sp.Spec.DefaultAction,
-		Architectures: sp.Spec.Architectures,
-		Flags:         sp.Spec.Flags,
+		DefaultAction:    sp.Spec.DefaultAction,
+		Architectures:    sp.Spec.Architectures,
+		ListenerPath:     sp.Spec.ListenerPath,
+		ListenerMetadata: sp.Spec.ListenerMetadata,
+		Flags:            sp.Spec.Flags,
 	}
 	baseProfileName := sp.Spec.BaseProfileName
 	if baseProfileName == "" {


### PR DESCRIPTION
Seccomp notify is a new feature in container runtimes introduced by
- https://github.com/opencontainers/runtime-spec PR 1074
- https://github.com/opencontainers/runc PR 2682 (available in runc 1.1.0)

This patch adds:
- The new seccomp action SCMP_ACT_NOTIFY to defer the decision to a
  seccomp agent
- The ListenerPath and ListenerMetadata fields so the runtime can
  contact the seccomp agent.

Note that the flag SECCOMP_FILTER_FLAG_NEW_LISTENER is not added. See
https://github.com/opencontainers/runtime-spec PR 1096 for details.

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
